### PR TITLE
feat: adds copy btn to codeblocks

### DIFF
--- a/frontend/src/app/components/uikitBlock/UikitBlock.tsx
+++ b/frontend/src/app/components/uikitBlock/UikitBlock.tsx
@@ -2,6 +2,9 @@ import { ReactNode } from "react";
 import { Highlight, themes } from "prism-react-renderer";
 import "./uikit-block.scss";
 import Typography from "@components/typography/Typography";
+import Button from "@components/button/Button";
+import { toast } from "react-toastify";
+import { useTranslation } from "react-i18next";
 
 interface IUikitBlock {
   title: string;
@@ -14,6 +17,13 @@ export default function UikitBlock({
   codeBlock,
   children,
 }: IUikitBlock) {
+  const { t } = useTranslation();
+
+  const onClickCopyBtn = async (content: string) => {
+    await navigator.clipboard.writeText(content);
+    toast.success(t("global__clipboard_copy"));
+  };
+
   return (
     <div className="uikit-block">
       <Typography.Heading4>{title}</Typography.Heading4>
@@ -29,6 +39,16 @@ export default function UikitBlock({
                   ))}
                 </div>
               ))}
+
+              <div className="uikit-block__copy-btn">
+                <Button
+                  variant="contained"
+                  size="small"
+                  onClick={() => onClickCopyBtn(codeBlock)}
+                >
+                  Copy
+                </Button>
+              </div>
             </pre>
           )}
         </Highlight>

--- a/frontend/src/app/components/uikitBlock/uikit-block.scss
+++ b/frontend/src/app/components/uikitBlock/uikit-block.scss
@@ -4,7 +4,14 @@
   gap: get-spacing(xs);
 
   &__pre {
-    padding: get-spacing(sm);
     border-radius: get-border-radius(sm);
+    padding: get-spacing(sm);
+    position: relative;
+  }
+
+  &__copy-btn {
+    position: absolute;
+    right: get-spacing(xxs);
+    top: get-spacing(xxs);
   }
 }

--- a/frontend/src/assets/locales/en.json
+++ b/frontend/src/assets/locales/en.json
@@ -8,6 +8,7 @@
   "global__version": "Version",
   "global__hide": "Hide",
   "global__close": "Close",
+  "global__clipboard_copy": "Copied to clipboard",
   "not_found__page_title": "Page not found",
   "not_found__title": "We're sorry, but the page you are looking for cannot be found.",
   "not_found__description": "Error code 404",

--- a/frontend/src/assets/locales/fr.json
+++ b/frontend/src/assets/locales/fr.json
@@ -8,6 +8,7 @@
   "global__version": "Version",
   "global__hide": "Cacher",
   "global__close": "Fermer",
+  "global__clipboard_copy": "Copié dans le presse-papiers",
   "not_found__page_title": "Page non trouvée",
   "not_found__title": "Nous sommes désolés, mais la page que vous recherchez semble introuvable.",
   "not_found__description": "Code d’erreur 404",


### PR DESCRIPTION
GitHub Issue or Internal Use Azure Devops Work Item ID: 
<!-- Relevant GitHub issue or Azure Devops Work Item ID
 -->

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [ ] Bug fix
 - [x] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:


## What is the current behavior?
You could only copy the code snippets by selecting the text and doing copy and paste.


## What is the new behavior?
There is now a copy button anchored on top right of every code blocks


## Checklist

Please check that your PR fulfills the following requirements:

- [ ] Documentation has been added/updated.

## Other information
<!-- Please provide any additional information if necessary -->

